### PR TITLE
Make this work with CentOS7

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ Requirements
 
  - ferm package
 
+Configuration files and variables structure
+-------------------------------------------
+
+ - roles/ansible-role-ferm-firewall/defaults/main.yml
+  - this is used in case there is no ferm\_rules defined any where else
+
+Example configuration:
+
+ - group\_vars/all/all
+  - this can have a ferm\_rules defined - used on all hosts
+ - group\_vars/group/group.yml
+  - this can have a ferm\_rules\_extra defined - used in addition to the ferm\_rules
+
 Role Variables
 --------------
 To configure ferm, you need to provide a key to associate a set of rules to a role/software. This way, rules splited in multiple var-files won't overwrite each other.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,6 @@ ferm_rules:
         - {rule: "mod state state (ESTABLISHED RELATED) ACCEPT;", comment: "connection tracking"}
         - {rule: "interface lo ACCEPT;", comment: "allow local packet"}
         - {rule: "proto icmp ACCEPT;", comment: "respond to ping"}
-        - {rule: "proto udp dport 500 ACCEPT;", comment: "Ipsec"}
         - {rule: "proto tcp dport ssh ACCEPT;", comment: "allow SSH connections"}
     - chain: OUTPUT
       domains:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,5 @@ ferm_rules:
           comment: "connection tracking: drop"
         - rule: "mod state state (ESTABLISHED RELATED) ACCEPT;"
           comment: "connection tracking"
+
+disable_other_firewalls: [firewalld]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 # This Playbook configure firewall 'ferm'
+- name: Install Ferm
+  action:
+    module: "{{ ansible_pkg_mgr }}"
+    name: ferm
+    state: present
+
 - name: Ferm | Display rules var
   debug: var="{{ferm_rules}}"
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,11 @@
 
 - name: Ferm | Include ferm.d directory
   lineinfile: dest=/etc/ferm/ferm.conf line="@include 'ferm.d/';" backup=yes insertbefore=BOF create=yes
+  when: ansible_os_family is not "RedHat"
+
+- name: Ferm | Include ferm.d directory
+  lineinfile: dest=/etc/ferm.conf line="@include 'ferm.d/';" backup=yes insertbefore=BOF create=yes
+  when: major_release is "7" and ansible_os_family is "RedHat"
 
 - name: Ferm | Create the ferm conf files
   template: src=ferm.conf.j2 dest=/etc/ferm/ferm.d/{{item.key}}.conf mode=0655 owner=root group=root backup=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,23 +15,35 @@
 - name: Ferm | Make sure the directory for firewall rules exist
   file: path=/etc/ferm state=directory owner=root group=root
 
-- name: Ferm | Create config directory
-  file: path=/etc/ferm/ferm.d state=directory owner=root group=root
+- name: Ferm | Create config directory for non-RedHat
+  file: path=/etc/ferm.d state=directory owner=root group=root
+  when: ansible_os_family != "RedHat"
 
-- name: Ferm | Include ferm.d directory on Debian
-  lineinfile: dest=/etc/ferm/ferm.conf line="@include 'ferm/ferm.d/';" backup=yes insertbefore=BOF create=yes
+- name: Ferm | Create config directory for RedHat
+  file: path=/etc/ferm/ferm.d state=directory owner=root group=root
+  when: ansible_os_family == "RedHat"
+
+- name: Ferm | Include ferm.d directory on non-RedHat
+  lineinfile: dest=/etc/ferm/ferm.conf line="@include 'ferm.d/';" backup=yes insertbefore=BOF create=yes
   when: ansible_os_family != "RedHat"
 
 - name: Ferm | Include ferm.d directory on RedHat
   lineinfile: dest=/etc/ferm.conf line="@include 'ferm/ferm.d/';" backup=yes insertbefore=BOF create=yes
   when: ansible_os_family == "RedHat"
 
-- name: Ferm | Create the ferm conf files
+- name: Ferm | Create the ferm conf files on non-RedHat
+  template: src=ferm.conf.j2 dest=/etc/ferm.d/{{item.key}}.conf mode=0655 owner=root group=root backup=yes
+  with_dict: ferm_rules
+  notify:
+    - reload ferm
+  when: ansible_os_family != "RedHat"
+
+- name: Ferm | Create the ferm conf files on RedHat
   template: src=ferm.conf.j2 dest=/etc/ferm/ferm.d/{{item.key}}.conf mode=0655 owner=root group=root backup=yes
   with_dict: ferm_rules
   notify:
     - reload ferm
-
+  when: ansible_os_family == "RedHat"
 
 - meta: flush_handlers
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,19 +32,34 @@
   lineinfile: dest=/etc/ferm.conf line="@include 'ferm/ferm.d/';" backup=yes insertbefore=BOF create=yes
   when: ansible_os_family == "RedHat"
 
-- name: Ferm | Create the ferm conf files on non-RedHat
+- name: Ferm | Create the default ferm conf files on non-RedHat
   template: src=ferm.conf.j2 dest=/etc/ferm.d/{{item.key}}.conf mode=0655 owner=root group=root backup=yes
   with_dict: ferm_rules
   notify:
     - reload ferm
   when: ansible_os_family != "RedHat"
 
-- name: Ferm | Create the ferm conf files on RedHat
+- name: Ferm | Create the default ferm conf files on RedHat
   template: src=ferm.conf.j2 dest=/etc/ferm/ferm.d/{{item.key}}.conf mode=0655 owner=root group=root backup=yes
   with_dict: ferm_rules
   notify:
     - reload ferm
   when: ansible_os_family == "RedHat"
+
+- name: Ferm | Create extra ferm conf files on non-RedHat
+  template: src=ferm.conf.j2 dest=/etc/ferm.d/{{item.key}}.conf mode=0655 owner=root group=root backup=yes
+  with_dict: ferm_rules_extra
+  notify:
+    - reload ferm
+  when: ansible_os_family != "RedHat" and ferm_rules_extra is defined
+
+- name: Ferm | Create extra ferm conf files on RedHat
+  template: src=ferm.conf.j2 dest=/etc/ferm/ferm.d/{{item.key}}.conf mode=0655 owner=root group=root backup=yes
+  with_dict: ferm_rules_extra
+  notify:
+    - reload ferm
+  when: ansible_os_family == "RedHat" and ferm_rules_extra is defined
+
 
 - meta: flush_handlers
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,8 @@
     state: present
 
 - name: Disable firewalld
-  service: name=firewalld state=stopped enabled=no
+  service: name={{ item }} state=stopped enabled=no
+  with_items: disable_other_firewalls
 
 - name: Ferm | Display rules var
   debug: var="{{ferm_rules}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,12 +15,12 @@
 - name: Ferm | Create config directory
   file: path=/etc/ferm/ferm.d state=directory owner=root group=root
 
-- name: Ferm | Include ferm.d directory
+- name: Ferm | Include ferm.d directory on Debian
   lineinfile: dest=/etc/ferm/ferm.conf line="@include 'ferm/ferm.d/';" backup=yes insertbefore=BOF create=yes
   when: ansible_os_family == "Debian"
 
-- name: Ferm | Include ferm.d directory
-  lineinfile: dest=/etc/ferm.conf line="@include 'ferm.d/';" backup=yes insertbefore=BOF create=yes
+- name: Ferm | Include ferm.d directory on RedHat
+  lineinfile: dest=/etc/ferm.conf line="@include 'ferm/ferm.d/';" backup=yes insertbefore=BOF create=yes
   when: ansible_os_family == "RedHat"
 
 - name: Ferm | Create the ferm conf files

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,9 @@
     name: ferm
     state: present
 
+- name: Disable firewalld
+  service: name=firewalld state=stopped enabled=no
+
 - name: Ferm | Display rules var
   debug: var="{{ferm_rules}}"
 
@@ -17,7 +20,7 @@
 
 - name: Ferm | Include ferm.d directory on Debian
   lineinfile: dest=/etc/ferm/ferm.conf line="@include 'ferm/ferm.d/';" backup=yes insertbefore=BOF create=yes
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family != "RedHat"
 
 - name: Ferm | Include ferm.d directory on RedHat
   lineinfile: dest=/etc/ferm.conf line="@include 'ferm/ferm.d/';" backup=yes insertbefore=BOF create=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,29 +8,19 @@
 
 - name: Ferm | Display rules var
   debug: var="{{ferm_rules}}"
-  tags:
-    - ferm
 
 - name: Ferm | Make sure the directory for firewall rules exist
   file: path=/etc/ferm state=directory owner=root group=root
-  tags:
-   - ferm
 
 - name: Ferm | Create config directory
   file: path=/etc/ferm/ferm.d state=directory owner=root group=root
-  tags:
-   - ferm
 
 - name: Ferm | Include ferm.d directory
-  lineinfile: dest=/etc/ferm/ferm.conf line="@include 'ferm.d/';" backup=yes insertbefore=BOF
-  tags:
-    - ferm
+  lineinfile: dest=/etc/ferm/ferm.conf line="@include 'ferm.d/';" backup=yes insertbefore=BOF create=yes
 
 - name: Ferm | Create the ferm conf files
   template: src=ferm.conf.j2 dest=/etc/ferm/ferm.d/{{item.key}}.conf mode=0655 owner=root group=root backup=yes
   with_dict: ferm_rules
-  tags:
-   - ferm
   notify:
     - reload ferm
 
@@ -40,5 +30,3 @@
 - name: reload ferm
   service: name=ferm state=restarted
   changed_when: False
-  tags:
-    - ferm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,12 +16,12 @@
   file: path=/etc/ferm/ferm.d state=directory owner=root group=root
 
 - name: Ferm | Include ferm.d directory
-  lineinfile: dest=/etc/ferm/ferm.conf line="@include 'ferm.d/';" backup=yes insertbefore=BOF create=yes
-  when: ansible_os_family is not "RedHat"
+  lineinfile: dest=/etc/ferm/ferm.conf line="@include 'ferm/ferm.d/';" backup=yes insertbefore=BOF create=yes
+  when: ansible_os_family == "Debian"
 
 - name: Ferm | Include ferm.d directory
   lineinfile: dest=/etc/ferm.conf line="@include 'ferm.d/';" backup=yes insertbefore=BOF create=yes
-  when: major_release is "7" and ansible_os_family is "RedHat"
+  when: ansible_os_family == "RedHat"
 
 - name: Ferm | Create the ferm conf files
   template: src=ferm.conf.j2 dest=/etc/ferm/ferm.d/{{item.key}}.conf mode=0655 owner=root group=root backup=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,11 +11,6 @@
   tags:
     - ferm
 
-- name: Ferm | Make sure ferm is installed
-  apt: name=ferm state=present
-  tags:
-   - ferm
-
 - name: Ferm | Make sure the directory for firewall rules exist
   file: path=/etc/ferm state=directory owner=root group=root
   tags:

--- a/templates/ferm.conf.j2
+++ b/templates/ferm.conf.j2
@@ -1,3 +1,4 @@
+#{{ ansible_managed }}
 {% for ferm in item.value %}
  {% if ferm.domains is defined %}
 domain ({% for domain in ferm.domains %}{{domain}} {% endfor %}) table {{ferm.table|default('filter')}} {


### PR DESCRIPTION
Hi!

I made some changes to make this work on a CentOS7.1 machine with ansible 1.9.3.
- config file is in /etc/ferm.conf
  - so include had to be updated
- removed the tag in the role - much nicer to have this where the role is specified, like:
  - { role: ansible-ferm-firewall, tags: [ 'firewall' ] }
- install ferm on not just apt :)
- added an {{ ansible_managed }} at the top of the files in ferm.d/ 
- stop/disable firewalld
